### PR TITLE
Add included to compound docs, even when empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,7 +221,7 @@ function toAPI(type, data, options) {
 	delete ret.attributes.id;
 	delete ret.attributes._id;
 
-	if (options.includedRelationships && options.includedRelationships.length) {
+	if (Array.isArray(options.includedRelationships)) {
 		ret.included = [];
 	}
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -210,7 +210,7 @@ describe('JSON API Plugin', () => {
 
 		it('should format data according to jsonapi.org spec', () => {
 			const model = new Model({id: 1, name: 'foo'});
-			const result = jsonapi.toAPI('models', model);
+			const result = jsonapi.toAPI('models', model, {includedRelationships: []});
 			assert.deepEqual(result, {
 				type: 'models',
 				id: 1,
@@ -219,7 +219,8 @@ describe('JSON API Plugin', () => {
 				},
 				relationships: {
 					foos: {data: []}
-				}
+				},
+				included: []
 			});
 		});
 


### PR DESCRIPTION
According to https://jsonapi.org/format/#fetching-includes

> If an endpoint supports the include parameter and a client supplies it:
> - The server’s response MUST be a compound document with an included key — even if that included key holds an empty array (because the requested relationships are empty).

This is relevant for autoRowConfigs in DrEdition, where an edition may not always have an autoRowConfig, but consumers would like them included when they do exist.